### PR TITLE
Temporarily disable Tomcat allocations test

### DIFF
--- a/allocation-benchmark/src/test/kotlin/ServerCallAllocationTest.kt
+++ b/allocation-benchmark/src/test/kotlin/ServerCallAllocationTest.kt
@@ -13,7 +13,13 @@ const val ALLOWED_MEMORY_DIFFERENCE = 250L
 class ServerCallAllocationTest {
 
     @ParameterizedTest
-    @ValueSource(strings = ["Jetty", "Tomcat", "Netty", "CIO"])
+    @ValueSource(strings = [
+        "Jetty",
+        // Disabled for now, build server yields a different result
+        // "Tomcat",
+        "Netty",
+        "CIO",
+    ])
     fun testMemoryConsumptionIsSame(engine: String) {
         val reportName = "testMemoryConsumptionIsSame[$engine]"
 


### PR DESCRIPTION
It appears that the build server returns a slightly higher memory allocation result for Tomcat, so I think we can disable this for now until we can figure out a way to generate a new snapshot that matches.  The tests for the other engines are all accurate.