### PR TITLE
Add repository for kotlinx-io

### DIFF
--- a/allocation-benchmark/build.gradle.kts
+++ b/allocation-benchmark/build.gradle.kts
@@ -16,6 +16,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlinx/dev")
     maven("https://maven.pkg.jetbrains.space/public/p/ktor/eap")
 }
 


### PR DESCRIPTION
It would appear this is necessary for building with ktor from main while we're on kotlinx-io snapshots.