### PR TITLE
KTOR-7941 Benchmark for reading lines in memory with ByteReadChannel

### DIFF
--- a/io-benchmarks/build.gradle.kts
+++ b/io-benchmarks/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     jmh(libs.ktor.io)
     jmh(libs.ktor.utils)
     jmh(libs.ktor.network)
+    jmh(libs.kotlinx.io)
     jmh(kotlin("test"))
 }
 

--- a/io-benchmarks/src/jmh/kotlin/io/ktor/benchmarks/IoOperationsBenchmarks.kt
+++ b/io-benchmarks/src/jmh/kotlin/io/ktor/benchmarks/IoOperationsBenchmarks.kt
@@ -1,0 +1,27 @@
+package io.ktor.benchmarks
+
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
+import org.openjdk.jmh.annotations.*
+import kotlin.test.*
+
+@State(Scope.Benchmark)
+class IoOperationsBenchmarks {
+
+    @Benchmark
+    fun readLines() = runBlocking {
+        var lineNumber = 0
+        var count = 0
+        val numberOfLines = 100_000
+        val channel = writer(Dispatchers.IO) {
+            for (line in generateSequence { "line ${lineNumber++}\n" }.take(numberOfLines))
+                channel.writeStringUtf8(line)
+        }.channel
+        val out = StringBuilder()
+        while (channel.readUTF8LineTo(out) && count < numberOfLines)
+            count++
+
+        assertEquals(numberOfLines, count)
+    }
+
+}

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,9 +1,10 @@
 [versions]
 
 kotlin = "2.0.21"
-ktor = "3.0.0-rc-1"
+ktor = "3.0.2"
 kotlinx-serialization = "1.7.3"
 kotlinx-atomicfu = "0.25.0"
+kotlinx-io = "0.6.0"
 okhttp = "4.12.0"
 apache-httpclient = "4.5.14"
 logback = "1.5.10"
@@ -34,6 +35,7 @@ apache-httpclient = { module = "org.apache.httpcomponents:httpclient", version.r
 
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 
 instrumenter = { module = "com.google.code.java-allocation-instrumenter:java-allocation-instrumenter", version.ref = "instrumenter" }
 


### PR DESCRIPTION
Here is the benchmark for reading lines.

Before fix:
```
9212,508 ±  25,420  ms/op
```

After fix:
```
14,074 ± 0,324  ms/op
```