### PR TITLE
Add allocations skill and reports for 3.4.0-3.4.1

### DIFF
--- a/.claude/skills/allocations/SKILL.md
+++ b/.claude/skills/allocations/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: allocations
+description: Use when working with Ktor memory allocation benchmarks — showing how allocations changed between versions, updating the committed baseline after PRs are merged, or preparing a release report. Also use when the user mentions allocation diffs, dump files, a TeamCity build URL for allocation tests, PR numbers that might affect allocations, or asks to "release" results for a new Ktor version.
+---
+
+## Overview
+
+Manages Ktor allocation benchmark data: diffing two versions, updating the committed baseline after PRs merge, and finalizing release reports.
+
+## Commands
+
+| Command | When to use |
+|---------|-------------|
+| `diff [OLD] [NEW]` | Print full per-file allocation diffs between two versions |
+| `update [hints...]` | Get fresh dumps, verify against known PRs/tasks, commit updated baseline |
+| `release [OLD] [NEW]` | Finalize pending.md into a versioned release report and bump the version |
+
+## Dispatch
+
+Infer the command from `$ARGUMENTS` and the surrounding conversation:
+
+- Two version numbers present + "diff" / "show diffs" / "show allocations" intent → **`diff`**, use them as OLD and NEW
+- Two version numbers present with report/publish intent → **`release`**, use them as OLD and NEW
+- "update", "baseline", "dump", PR numbers, or YouTrack task IDs present → **`update`**, treat any PR/task refs as hints
+- Genuinely ambiguous → ask the user
+
+**`release`** — Read and follow `@references/release.md`.
+
+**`update`** — Read and follow `@references/update.md`.
+
+**`diff`** — Run from the ktor-benchmarks root and print the output:
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/compute_diff.py vOLD..vNEW
+```
+For `NEW = main`, use `main` as the git ref. Version tags follow the `vX.Y.Z` convention.
+
+---
+
+## Prerequisites
+
+Resolve each item below **at the point it is first needed** — not upfront. Each reference file will say "resolve X — see Prerequisites in SKILL.md" when it requires something here.
+
+**Ktor repo path**
+Check memory for a saved ktor repo path. If found, verify it is still valid (`ls KTOR_REPO_PATH/VERSION`). If missing or invalid, ask the user where the ktor repo is cloned (offer to clone to `/tmp/ktor` if needed). Save the resolved path to memory.
+
+**TC CLI**
+Run `tc auth status`. If not found or not authenticated, use the `teamcity-cli:teamcity-cli` skill for setup before proceeding.
+
+**gh CLI**
+Run `gh auth status`. If not authenticated, run `gh auth login` before proceeding.
+
+**YouTrack MCP**
+Call `search_issues` with query `project: KTOR #Resolved` limit 1. If unavailable, note it — the step that needs it will skip the YouTrack sub-step and rely on `git log` + `gh` only.

--- a/.claude/skills/allocations/references/investigate-diff.md
+++ b/.claude/skills/allocations/references/investigate-diff.md
@@ -1,0 +1,63 @@
+# Investigating allocation diffs
+
+## Reading the diff output
+
+From `compute_diff.py` output, identify:
+
+**Consistent changes** — files that moved by a similar amount across *multiple* engines/scenarios point to a shared cause.
+
+**Large outliers** — a single-file change that is 10× larger than the rest deserves individual explanation.
+
+**Correlated files** — files that always move together probably share a root cause; group them.
+
+## Quick investigation — inspecting call sites
+
+For any change that is unclear, use `check_sites.py` to see added/removed/changed stack traces for a specific source file. Run from the ktor-benchmarks root.
+
+The `SCENARIO[ENGINE]` argument is the path relative to the allocations root without the `_sites.json` suffix — e.g. `helloWorld[CIO]` or `client/streamingResponse[CIO]`. The square brackets and engine name are literal.
+
+**Local mode** (new dumps in `build/allocations/`):
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/check_sites.py --local \
+  "SCENARIO[ENGINE]" \
+  FileName.kt
+```
+
+**Git mode** (comparing two commits). For a release use `vOLD..vNEW`; for an in-progress update where the new tag doesn't exist yet, omit `..vNEW` — it defaults to `HEAD`:
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/check_sites.py vOLD_VERSION[..vNEW_VERSION] \
+  "SCENARIO[ENGINE]" \
+  FileName.kt
+```
+
+The class names and stack frames in the output are authoritative: they confirm exactly what is being allocated and from which call path.
+
+## Deep investigation — attributing changes to PRs
+
+Use this when no PR hints were provided, or to confirm an attribution that is still unclear after inspecting call sites.
+
+Resolve **Ktor repo path** — see Prerequisites in SKILL.md.
+
+The caller must supply the git commit range (e.g. `vOLD..vNEW` for a release, `v{PREV_VERSION}..HEAD` for an in-progress update).
+
+**a) For each file showing a significant change, find which commit in the range touched it:**
+```bash
+git log --oneline RANGE -- "**/TheFile.kt"
+```
+
+**b) Get PR details for relevant commits** — resolve **gh CLI** (see Prerequisites in SKILL.md):
+```bash
+gh pr view PR_NUMBER --repo ktorio/ktor --json title,body
+```
+
+**c) Extract YouTrack issue ID** — check the PR title and body (from step b) for a `KTOR-XXXX` reference. This is the fastest path and usually sufficient.
+
+If no issue ID is found in the PR, fall back to **YouTrack MCP** — resolve **YouTrack MCP** (see Prerequisites in SKILL.md); skip if unavailable. Search for issues resolved in the relevant release:
+```text
+project: KTOR {Target release}: VERSION #Resolved
+```
+Cross-reference the YouTrack issues with the commits and PRs to confirm attribution.
+
+Attribution format in reports: `[KTOR-XXXX / #YYYY](PR_URL)` — both the YouTrack issue ID and the PR number in the link text, linking to the PR URL. Omit the YouTrack part if no issue is associated.
+
+If no commit or PR can be found for a significant change, write "cause under investigation" — don't omit the change.

--- a/.claude/skills/allocations/references/release.md
+++ b/.claude/skills/allocations/references/release.md
@@ -1,0 +1,59 @@
+# Release workflow
+
+Finalize `pending.md` into a versioned release report. Follow every step below in order.
+
+---
+
+## Step 1 — Ensure fresh dumps are committed
+
+Verify the `vOLD_VERSION` tag exists:
+```bash
+git show vOLD_VERSION --no-patch
+```
+
+If the tag is missing, stop and ask the user to create it before proceeding.
+
+Check whether new dumps are committed on HEAD:
+```bash
+git log --oneline -1 -- allocation-benchmark/allocations/
+```
+
+If the most recent commit touching `allocations/` is the same commit as `vOLD_VERSION` (i.e. no new dumps have been committed since the last release), follow Steps 1–4 from `references/update.md` to obtain and commit fresh dumps before continuing.
+
+---
+
+## Step 2 — Promote pending.md to a versioned report
+
+Rename the file and update its header line:
+
+```bash
+git mv allocation-benchmark/pending.md allocation-benchmark/NEW_VERSION.md
+```
+
+Update the header line from:
+
+```markdown
+## Allocation Benchmark Results: OLD_VERSION → (pending)
+```
+
+to:
+
+```markdown
+## Allocation Benchmark Results: OLD_VERSION → NEW_VERSION
+```
+
+---
+
+## Step 3 — Bump the version in libs.versions.toml
+
+Update the `ktor` key under `[versions]` in `libs.versions.toml` (at the ktor-benchmarks root) to `NEW_VERSION`.
+
+---
+
+## Step 4 — Commit
+
+```bash
+git add allocation-benchmark/NEW_VERSION.md libs.versions.toml
+git commit -m "Add allocation report for NEW_VERSION"
+```
+

--- a/.claude/skills/allocations/references/report-template.md
+++ b/.claude/skills/allocations/references/report-template.md
@@ -1,0 +1,80 @@
+# Report template
+
+Use this structure for both release reports and `pending.md`. Scenario names and engine lists come from `compute_diff.py` output — do not hardcode them.
+
+For `pending.md`, replace the header version line with `PREV_VERSION → (pending)` as instructed in `update.md` Step 3. In the TIP block, use `main` as `NEW_VERSION` (e.g. `OLD_VERSION..main` / `vOLD_VERSION..main`) since the new version has no tag yet.
+
+```markdown
+## Allocation Benchmark Results: OLD_VERSION → NEW_VERSION
+
+> ⚠️ This report was generated with AI assistance and may contain incorrect attributions or false claims. Please verify before publishing.
+
+### Key Takeaways
+
+**Improvements**
+
+- **[Plain-English description of what improved and why it matters.]**
+  [KTOR-XXXX / #YYYY](PR_URL) — one sentence on the mechanism (what was removed/optimized). Omit the YouTrack part if no issue is associated.
+
+**Regressions**
+
+- **[Plain-English description of what increased and why.]**
+  [PR_LINK] — one sentence explaining the trade-off or correctness reason.
+
+---
+
+### Client
+
+<details>
+<summary><code>scenarioA</code> · <code>scenarioB</code> · ...</summary>
+
+#### `scenarioA` — [short description]
+
+| Engine | Consumed (NEW) | Baseline (OLD) | Δ |
+|--------|---------------|----------------|---|
+| CIO    | X KB | X KB | **−X bytes (−X%)** |
+| Apache | X KB | X KB | **−X bytes** |
+| OkHttp | X KB | X KB | **−X bytes** |
+| Java   | X KB | X KB | **−X bytes** |
+
+... (repeat for each client scenario)
+
+</details>
+
+---
+
+### Server
+
+<details>
+<summary><code>scenarioA</code> · <code>scenarioB</code> · ...</summary>
+
+... (same structure, with engines discovered from the files)
+
+</details>
+
+> [!TIP]
+> To see full per-file allocation diffs, ask Claude: *"show allocation diffs for OLD_VERSION..NEW_VERSION"*,
+> or run the script manually:
+> ```
+> python3 .claude/skills/allocations/scripts/compute_diff.py vOLD_VERSION..vNEW_VERSION
+> ```
+```
+
+---
+
+## Key Takeaways guidelines
+
+- Lead with the **user-visible outcome** ("X no longer allocated per request"), not a file or component name.
+- State percentages for large changes (≥5%); use absolute bytes for small ones.
+- When multiple PRs combine to produce a consistent per-engine improvement, add one summary bullet with the net effect.
+- When a PR causes both a saving and a regression, cover both in **one bullet** as a trade-off.
+- Omit items smaller than ~50 bytes across all engines — measurement noise.
+- Regressions must state the trade-off or correctness reason.
+- If a change is a measurement artefact (e.g. Kotlin codegen line-number shifts), call it out explicitly.
+- If attribution is uncertain, say "cause under investigation".
+
+## Per-engine table formatting
+
+- Use `X KB` with two decimal places for totals (e.g. `46.20 KB`).
+- Engine order: CIO · Apache · OkHttp · Java (client) or Jetty · Tomcat · Netty · CIO (server).
+- State percentages for large per-scenario changes (≥5%); omit for small ones.

--- a/.claude/skills/allocations/references/update.md
+++ b/.claude/skills/allocations/references/update.md
@@ -1,0 +1,117 @@
+# Update workflow
+
+Update the committed allocation baseline (`allocations/`) to reflect merged PRs, so improvements aren't lost in subsequent work. The user may provide hints — PR numbers or YouTrack task IDs — for changes they expect to see.
+
+---
+
+## Step 1 — Get fresh dumps
+
+Choose the approach based on what the user provided — only ask if neither applies:
+
+- User gave a TC build URL → Option B
+- User wants to test a local/unreleased build → Option A
+
+### Option A — Run locally
+
+Use when you want to benchmark a specific local Ktor build (e.g. an unreleased change).
+
+First, if testing against a locally-built Ktor version, publish it to Maven Local from the ktor repository. Resolve the ktor repo path — see **Ktor repo path** in Prerequisites (SKILL.md).
+
+```bash
+# In the ktor repo directory
+./gradlew publishJvmAndCommonPublications
+```
+
+The version being published is in `{ktor-repo}/VERSION`. To use a specific version string, pass `-Pversion=X.Y.Z-SNAPSHOT`.
+
+Then run the benchmarks from the ktor-benchmarks root:
+
+```bash
+./gradlew :allocation-benchmark:test
+```
+
+This runs all allocation tests and writes new dumps to `allocation-benchmark/build/allocations/` (dumps are saved before assertions, so files are available even if the task fails). If the task fails due to a threshold exceeded, flag it to the user — it may indicate an unexpected regression alongside the intended improvement.
+
+### Option B — Fetch from TeamCity CI
+
+Use when CI already ran the benchmarks and you just want the results.
+
+Resolve **TC CLI** — see Prerequisites in SKILL.md.
+
+Ask the user for a link to the relevant `Ktor_AllocationTests` build. Extract the build ID from the URL — it is the last numeric segment:
+
+```text
+https://ktor.teamcity.com/buildConfiguration/Ktor_AllocationTests/413598
+                                                                   ^^^^^^ build ID
+```
+
+Download and extract the new dumps:
+
+```bash
+tc run download BUILD_ID --artifact "new_allocations.zip" --dir /tmp/tc-alloc/
+unzip -o /tmp/tc-alloc/new_allocations.zip -d allocation-benchmark/build/allocations/
+```
+
+The zip preserves the `client/` subdirectory structure.
+
+Save the TC build URL — you will include it in `pending.md` so readers can inspect the raw results manually.
+
+---
+
+## Step 2 — Compute diff
+
+Both options place new dumps in `build/allocations/`, so always run:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/compute_diff.py --local
+```
+
+Collect per-scenario totals and per-file deltas.
+
+---
+
+## Step 3 — Verify against hints and update pending.md
+
+Read `${CLAUDE_SKILL_DIR}/references/investigate-diff.md` for how to analyse the diff output.
+
+If the user provided no hints, ask for them before proceeding — PR numbers or YouTrack IDs let you skip the slow deep investigation. If they cannot provide any, proceed with the deep investigation from `investigate-diff.md` using range `v{PREV_VERSION}..HEAD` in the ktor repo, where `PREV_VERSION` is the current `ktor` version from `libs.versions.toml`.
+
+If the user provided PR numbers or task IDs, cross-reference them against the diff:
+
+- **Expected change present?** Confirm that files touched by each hinted PR show a delta.
+- **Unexpected changes?** For any significant change not explained by the hints, run `check_sites.py` (see `investigate-diff.md`) to determine the cause **before** presenting findings to the user. Only mark a change as "cause under investigation" if the call sites are also inconclusive.
+- **Expected change missing?** Warn the user — the benchmark may not cover that code path, or the change may not affect allocations.
+
+Summarise findings — confirmed, missing, unexplained — and wait for the user to confirm before proceeding.
+
+Once the user confirms, update `allocation-benchmark/pending.md`:
+
+If the file does not exist yet, create it with the header. `PREV_VERSION` is the current Ktor version from `libs.versions.toml` in the ktor-benchmarks root (the `ktor` key under `[versions]`):
+
+```markdown
+## Allocation Benchmark Results: PREV_VERSION → (pending)
+
+> ⚠️ This report was generated with AI assistance and may contain incorrect attributions or false claims. Please verify before publishing.
+```
+
+Read `${CLAUDE_SKILL_DIR}/references/report-template.md` for the full structure. Add or update the Key Takeaways bullets and per-scenario tables to reflect the confirmed changes. Use the PR hints as attribution. Mark uncertain attributions as "cause under investigation".
+
+If dumps were fetched via Option B (TeamCity), append the following line at the end of the file so readers can inspect the raw results manually:
+
+```markdown
+> Source: [TeamCity build](TC_BUILD_URL)
+```
+
+---
+
+## Step 4 — Commit the updated baseline
+
+Copy the new dumps into the baseline, then commit:
+
+```bash
+cp -r allocation-benchmark/build/allocations/. allocation-benchmark/allocations/
+git add allocation-benchmark/allocations/ allocation-benchmark/pending.md
+git commit -m "Update allocation baselines
+
+Reflects changes from: PR #X, PR #Y (KTOR-NNNN)"
+```

--- a/.claude/skills/allocations/scripts/check_sites.py
+++ b/.claude/skills/allocations/scripts/check_sites.py
@@ -1,0 +1,167 @@
+"""
+Show added/removed allocation call sites for a specific source file.
+
+Modes:
+  python check_sites.py OLD_COMMIT[..NEW_COMMIT] SCENARIO SOURCE_FILE
+      Compare _sites.json from two git commits.
+      NEW_COMMIT defaults to HEAD if omitted.
+
+  python check_sites.py --local SCENARIO SOURCE_FILE
+      Compare local build/allocations/ against local allocations/.
+
+SCENARIO: path to _sites.json relative to the allocations root, without extension
+          e.g. helloWorld[CIO]  or  client/streamingResponse[CIO]
+SOURCE_FILE: source file name to inspect, e.g. ByteChannel.kt
+
+Run from the ktor-benchmarks repository root.
+"""
+
+import sys
+
+from sources import git_sources, local_sources
+
+
+# ---------------------------------------------------------------------------
+# Mode selection
+# ---------------------------------------------------------------------------
+
+if len(sys.argv) >= 2 and sys.argv[1] == "--local":
+    if len(sys.argv) < 4:
+        print(__doc__)
+        sys.exit(1)
+    scenario = sys.argv[2]
+    source_file = sys.argv[3]
+    old_source, new_source = local_sources()
+    mode = "--local"
+else:
+    if len(sys.argv) < 4:
+        print(__doc__)
+        sys.exit(1)
+    old_source, new_source = git_sources(sys.argv[1])
+    scenario = sys.argv[2]
+    source_file = sys.argv[3]
+    mode = f"{old_source.ref}..{new_source.ref}"
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+def top_frame(s):
+    return s["stackTrace"].split(", ")[0].split(":")[0]
+
+
+def group_by_file(sites):
+    by_file = {}
+    for s in sites:
+        by_file.setdefault(top_frame(s), []).append(s)
+    return by_file
+
+
+def format_frames(stack_trace):
+    """Format up to 4 frames from a raw stackTrace string, collapsing consecutive
+    frames from the same file into a single token with multiple line numbers.
+
+    Frame separator is ' <- ' (call direction: allocating site on the left).
+    Consecutive same-file frames are collapsed: 'File.kt:21:52' means lines 21
+    and 52 of File.kt appeared as adjacent frames.
+    """
+    frames = stack_trace.split(", ")[:4]
+    result = []
+    i = 0
+    while i < len(frames):
+        file = frames[i].split(":")[0]
+        lines = []
+        while i < len(frames) and frames[i].split(":")[0] == file:
+            parts = frames[i].split(":")
+            if len(parts) > 1:
+                lines.append(parts[1])
+            i += 1
+        token = file + (":" + ":".join(lines) if lines else "")
+        result.append(token)
+    return " <- ".join(result)
+
+
+def stable_key(stack_trace):
+    """
+    Normalize caller line numbers so traces differing only in caller shifts match.
+
+    Keeps the top (allocating) frame line number intact so two distinct call sites
+    in the inspected file are never merged. Strips line numbers only from caller
+    frames, which loses the exact caller line in CHANGED output but avoids spurious
+    ADDED/REMOVED pairs when unrelated Ktor code insertions shift caller lines.
+
+    Output format: 'file:line' for frame 0, bare 'file' for frames 1+.
+    Used only for grouping — display uses the original stackTrace.
+    """
+    frames = stack_trace.split(", ")
+    normalized = [frames[0]] + [f.split(":")[0] for f in frames[1:]]
+    return ", ".join(normalized)
+
+
+def build_map(sites):
+    """Build {stable_key: site} merging entries that share the same stable stack trace.
+
+    When two raw entries share a stable key (caller line numbers differed), their
+    totalSize values are summed. All other fields (name, stackTrace, …) are kept
+    from the first occurrence. This is safe because stable_key preserves the top
+    frame's line number, so two sites that allocate *different types* at *different
+    lines* in the inspected file always produce distinct keys and are never merged.
+    """
+    result = {}
+    for s in sites:
+        key = stable_key(s["stackTrace"])
+        if key in result:
+            result[key] = dict(result[key], totalSize=result[key]["totalSize"] + s["totalSize"])
+        else:
+            result[key] = s
+    return result
+
+
+try:
+    new_sites = new_source.load_sites(scenario, required=True)
+except FileNotFoundError as e:
+    print(f"ERROR: {e}", file=sys.stderr)
+    sys.exit(1)
+old_sites = old_source.load_sites(scenario, required=False)
+
+old_by_file = group_by_file(old_sites)
+new_by_file = group_by_file(new_sites)
+
+if source_file not in old_by_file and source_file not in new_by_file:
+    print(f"ERROR: '{source_file}' not found in either snapshot — check spelling", file=sys.stderr)
+    print(f"Known files: {', '.join(sorted(set(old_by_file) | set(new_by_file))[:20])}", file=sys.stderr)
+    sys.exit(1)
+
+o_map = build_map(old_by_file.get(source_file, []))
+n_map = build_map(new_by_file.get(source_file, []))
+
+added = {k: v for k, v in n_map.items() if k not in o_map}
+removed = {k: v for k, v in o_map.items() if k not in n_map}
+changed = {
+    k: (o_map[k], n_map[k])
+    for k in o_map
+    if k in n_map and o_map[k]["totalSize"] != n_map[k]["totalSize"]
+}
+
+if not added and not removed and not changed:
+    sys.exit(0)
+
+print(f"\n{scenario} / {source_file}  {mode}")
+
+entries = []
+
+for _, s in added.items():
+    n = s["totalSize"]
+    entries.append((n, f"  +{n:,}  [{s['name']}]  {format_frames(s['stackTrace'])}"))
+
+for _, s in removed.items():
+    o = s["totalSize"]
+    entries.append((-o, f"  -{o:,}  [{s['name']}]  {format_frames(s['stackTrace'])}"))
+
+for _, (old_s, new_s) in changed.items():
+    delta = new_s["totalSize"] - old_s["totalSize"]
+    entries.append((delta, f"  {delta:+,} ({old_s['totalSize']:,} → {new_s['totalSize']:,})  [{new_s['name']}]  {format_frames(new_s['stackTrace'])}"))
+
+for _, line in sorted(entries, key=lambda x: (int(x[0] < 0), -abs(x[0]))):
+    print(line)

--- a/.claude/skills/allocations/scripts/compute_diff.py
+++ b/.claude/skills/allocations/scripts/compute_diff.py
@@ -1,0 +1,126 @@
+"""
+Compute per-file allocation diffs across all discovered scenarios.
+
+Modes:
+  python compute_diff.py OLD_COMMIT[..NEW_COMMIT]
+      Compare allocation dumps from two git commits.
+      NEW_COMMIT defaults to HEAD if omitted.
+
+  python compute_diff.py --local
+      Compare local build/allocations/ against local allocations/.
+
+Options:
+  --threshold N   Hide per-file entries with |delta| < N bytes (default: 50).
+                  Use --threshold 0 to show all entries.
+                  Affects only changed sites, added and removed sites are always shown.
+
+Run from the ktor-benchmarks repository root.
+"""
+
+import re
+import subprocess
+import sys
+
+from sources import git_sources, local_sources
+
+SUBDIRS = {"server": "", "client": "client"}
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+args = sys.argv[1:]
+
+threshold = 50
+if "--threshold" in args:
+    i = args.index("--threshold")
+    try:
+        threshold = int(args[i + 1])
+    except (IndexError, ValueError):
+        print("ERROR: --threshold requires a non-negative integer argument", file=sys.stderr)
+        sys.exit(1)
+    if threshold < 0:
+        print("ERROR: --threshold must be non-negative", file=sys.stderr)
+        sys.exit(1)
+    args = args[:i] + args[i + 2:]
+
+if args and args[0] == "--local":
+    old_source, new_source = local_sources()
+    mode = "--local"
+else:
+    if not args:
+        print(__doc__)
+        sys.exit(1)
+    old_source, new_source = git_sources(args[0])
+    mode = f"{old_source.ref}..{new_source.ref}"
+
+print(f"{mode}  --threshold={threshold}")
+
+
+# ---------------------------------------------------------------------------
+# Diff computation
+# ---------------------------------------------------------------------------
+
+def extract(data):
+    return {k: v["locationSize"] for k, v in data["data"].items()}
+
+
+def try_load(source, subdir, fname):
+    try:
+        return extract(source.load(subdir, fname))
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+
+results = {}
+for side, subdir in SUBDIRS.items():
+    all_fnames = set(old_source.list_files(subdir)) | set(new_source.list_files(subdir))
+    for fname in sorted(all_fnames):
+        m = re.match(r"^(.+)\[(.+)\]\.json$", fname)
+        if not m:
+            continue
+        scenario, engine = m.group(1), m.group(2)
+        key = f"{side}/{scenario}"
+        old = try_load(old_source, subdir, fname)
+        new = try_load(new_source, subdir, fname)
+        if old is None and new is None:
+            continue
+        old = old or {}
+        new = new or {}
+        old_total = sum(old.values())
+        new_total = sum(new.values())
+        diffs = []
+        for k in set(old) | set(new):
+            d = new.get(k, 0) - old.get(k, 0)
+            if d != 0:
+                diffs.append((d, k, old.get(k, 0), new.get(k, 0)))
+        diffs.sort(key=lambda x: (int(x[0] < 0), -abs(x[0])))
+        results.setdefault(key, {})[engine] = {
+            "old_total": old_total,
+            "new_total": new_total,
+            "delta": new_total - old_total,
+            "diffs": diffs,  # list of (delta, filename, old, new)
+        }
+
+for scenario, engines in results.items():
+    print(f"\n{scenario}")
+    for engine, data in engines.items():
+        delta = data["delta"]
+        old_kb = data["old_total"] / 1024
+        new_kb = data["new_total"] / 1024
+        print(f"  {engine}: {old_kb:.2f} KB → {new_kb:.2f} KB  ({delta:+,})")
+        hidden_count = 0
+        hidden_sum = 0
+        for d, fname, o, n in data["diffs"]:
+            if o == 0:
+                print(f"    +{n:,}  {fname}")
+            elif n == 0:
+                print(f"    -{o:,}  {fname}")
+            elif abs(d) < threshold:
+                hidden_count += 1
+                hidden_sum += d
+            else:
+                print(f"    {d:+,} ({o:,} → {n:,})  {fname}")
+        if hidden_count:
+            print(f"    ({hidden_count} below threshold, net {hidden_sum:+,})")

--- a/.claude/skills/allocations/scripts/sources.py
+++ b/.claude/skills/allocations/scripts/sources.py
@@ -1,0 +1,93 @@
+"""Shared allocation data sources for compute_diff.py and check_sites.py."""
+
+import json
+import os
+import subprocess
+
+REPO = os.getcwd()
+ALLOC_GIT_ROOT = "allocation-benchmark/allocations"
+ALLOC_LOCAL_ROOT = "allocation-benchmark/build/allocations"
+
+
+class GitSource:
+    def __init__(self, ref):
+        try:
+            subprocess.check_output(
+                ["git", "rev-parse", "--verify", ref], cwd=REPO, stderr=subprocess.DEVNULL
+            )
+        except subprocess.CalledProcessError:
+            raise ValueError(f"Invalid git ref: {ref!r}") from None
+        self.ref = ref
+
+    def list_files(self, subdir):
+        git_dir = f"{ALLOC_GIT_ROOT}/{subdir}".rstrip("/")
+        try:
+            out = subprocess.check_output(
+                ["git", "ls-tree", "--name-only", f"{self.ref}:{git_dir}"], cwd=REPO
+            ).decode()
+        except subprocess.CalledProcessError:
+            return []
+        return [f for f in out.splitlines() if f.endswith(".json") and "_sites" not in f]
+
+    def load(self, subdir, fname):
+        git_dir = f"{ALLOC_GIT_ROOT}/{subdir}".rstrip("/")
+        raw = subprocess.check_output(
+            ["git", "show", f"{self.ref}:{git_dir}/{fname}"], cwd=REPO
+        )
+        return json.loads(raw)
+
+    def load_sites(self, scenario, required=True):
+        path = f"{ALLOC_GIT_ROOT}/{scenario}_sites.json"
+        result = subprocess.run(
+            ["git", "show", f"{self.ref}:{path}"], cwd=REPO, capture_output=True
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            if required:
+                raise FileNotFoundError(f"{path} not found at {self.ref!r}")
+            return []
+        return json.loads(result.stdout)
+
+
+class LocalSource:
+    def __init__(self, root=ALLOC_LOCAL_ROOT):
+        if not os.path.isdir(root):
+            raise FileNotFoundError(f"Directory not found: {root}")
+        self.root = root
+
+    def list_files(self, subdir):
+        local_dir = os.path.join(self.root, subdir) if subdir else self.root
+        if not os.path.isdir(local_dir):
+            return []
+        return [f for f in os.listdir(local_dir) if f.endswith(".json") and "_sites" not in f]
+
+    def load(self, subdir, fname):
+        local_dir = os.path.join(self.root, subdir) if subdir else self.root
+        with open(os.path.join(local_dir, fname)) as f:
+            return json.load(f)
+
+    def load_sites(self, scenario, required=True):
+        path = os.path.join(self.root, f"{scenario}_sites.json")
+        if not os.path.exists(path):
+            if required:
+                raise FileNotFoundError(f"{path} not found")
+            return []
+        with open(path) as f:
+            return json.load(f)
+
+
+def git_sources(ref):
+    """Parse 'OLD[..NEW]' and return (GitSource, GitSource), defaulting NEW to HEAD."""
+    if ".." in ref:
+        old, new = ref.split("..", 1)
+    else:
+        old, new = ref, "HEAD"
+    return GitSource(old), GitSource(new)
+
+
+def local_sources():
+    """Return (old, new) as LocalSource instances for local mode.
+
+    old: allocation-benchmark/allocations/ (committed baseline)
+    new: allocation-benchmark/build/allocations/ (freshly generated dumps)
+    """
+    return LocalSource(root=os.path.join(REPO, ALLOC_GIT_ROOT)), LocalSource()

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ gradle-app.setting
 # Kotlin
 .kotlin
 
+# Python
+__pycache__

--- a/allocation-benchmark/3.4.0.md
+++ b/allocation-benchmark/3.4.0.md
@@ -1,0 +1,104 @@
+## Allocation Benchmark Results: 3.3.0 → 3.4.0
+
+> ⚠️ This report was generated with AI assistance and may contain incorrect attributions or false claims. Please verify before publishing.
+
+### Key Takeaways
+
+**Improvements**
+
+- **Jetty server request handling eliminates a redundant coroutine scope per call, saving 695–937 bytes per request.**
+  [#5170](https://github.com/ktorio/ktor/pull/5170) (KTOR-9054) — correcting the coroutine job hierarchy removed the `JettyRequestBodyReader` coroutine and its associated write-channel infrastructure entirely; `ByteWriteChannelOperations`, `ByteChannel`, and `SuspendFunctionGun` allocations all dropped or went to zero.
+
+**Regressions**
+
+- **Chunked streaming responses allocate significantly more per request — CIO streaming up +69 KB (+3%), gzip up +28 KB; Apache, OkHttp, and Java streaming up 8–21 KB.**
+  [#5236](https://github.com/ktorio/ktor/pull/5236) (KTOR-9171) — the redesigned `readUTF8Line` / `internalReadLineTo` called by `decodeChunked` creates per-chunk coroutine lambdas, boxed `Long`s, and `LongRef`s that did not exist before; `ByteChannel.flush()` is now a separate suspension point in the chunked path, adding a continuation per chunk. Trade-off: 2–6× speedup for long-line reading.
+
+- **Every server request now parses the HTTP version string, costing ~816 bytes per 300 requests on all engines.**
+  [#5215](https://github.com/ktorio/ktor/pull/5215) (KTOR-9125) — `DefaultEnginePipeline` now calls `HttpProtocolVersion.parse()` to skip body-drain for HTTP/2+ connections, allocating a new `HttpProtocolVersion` instance per call. CIO pays double (1,632 bytes) as it already parsed the version in its engine path.
+
+- **Netty `fileResponse` shows −1,751 bytes in `NettyHttpResponsePipeline.kt`, but this is a measurement artefact.**
+  The Kotlin 2.3 upgrade shifted `ContinuationImpl` line numbers (`:33`→`:34`), causing the benchmark to record the same allocation sites as separate entries with different totals rather than a true reduction.
+
+---
+
+### Client
+
+<details>
+<summary><code>helloWorld</code> · <code>fileResponse</code> · <code>gzipResponse</code> · <code>streamingResponse</code></summary>
+
+#### `helloWorld` — simple request/response
+
+| Engine | Consumed (3.4.0) | Baseline (3.3.0) | Δ |
+|--------|-----------------|-----------------|---|
+| CIO    | 50.36 KB | 50.14 KB | **+217 bytes** |
+| Apache | 34.45 KB | 34.39 KB | **+56 bytes** |
+| OkHttp | 31.31 KB | 31.19 KB | **+123 bytes** |
+| Java   | 34.00 KB | 34.08 KB | **−87 bytes** |
+
+#### `fileResponse` — file download
+
+| Engine | Consumed (3.4.0) | Baseline (3.3.0) | Δ |
+|--------|-----------------|-----------------|---|
+| CIO    | 2370.17 KB | 2370.35 KB | **−187 bytes** |
+| Apache | 2349.38 KB | 2349.46 KB | **−87 bytes** |
+| OkHttp | 2349.05 KB | 2349.02 KB | **+30 bytes** |
+| Java   | 2352.34 KB | 2352.47 KB | **−133 bytes** |
+
+Note: all changes are within measurement noise (< 200 bytes).
+
+#### `gzipResponse` — gzip-compressed response body
+
+| Engine | Consumed (3.4.0) | Baseline (3.3.0) | Δ |
+|--------|-----------------|-----------------|---|
+| CIO    | 6430.22 KB | 6402.84 KB | **+28,046 bytes (+0.43%)** |
+| Apache | 6213.56 KB | 6213.75 KB | **−193 bytes** |
+| OkHttp | 6230.27 KB | 6230.30 KB | **−35 bytes** |
+| Java   | 6294.09 KB | 6295.51 KB | **−1,453 bytes** |
+
+#### `streamingResponse` — streaming response body (chunked)
+
+| Engine | Consumed (3.4.0) | Baseline (3.3.0) | Δ |
+|--------|-----------------|-----------------|---|
+| CIO    | 2369.95 KB | 2302.67 KB | **+68,886 bytes (+2.9%)** |
+| Apache | 2123.22 KB | 2114.69 KB | **+8,732 bytes** |
+| OkHttp | 3225.91 KB | 3205.26 KB | **+21,142 bytes** |
+| Java   | 2214.03 KB | 2196.16 KB | **+18,300 bytes** |
+
+All engines regressed. Call-site analysis confirms the increases originate in `decodeChunked` calling the new `internalReadLineTo` and `copyTo` paths from PR #5236 (KTOR-9171).
+
+</details>
+
+---
+
+### Server
+
+<details>
+<summary><code>helloWorld</code> · <code>fileResponse</code></summary>
+
+#### `helloWorld` — simple request/response
+
+| Engine | Consumed (3.4.0) | Baseline (3.3.0) | Δ |
+|--------|-----------------|-----------------|---|
+| Jetty  | 10.53 KB | 11.21 KB | **−695 bytes** |
+| Tomcat | 17.15 KB | 16.61 KB | **+560 bytes** |
+| Netty  | 10.66 KB | 10.15 KB | **+520 bytes** |
+| CIO    | 19.79 KB | 18.81 KB | **+1,008 bytes** |
+
+#### `fileResponse` — file download
+
+| Engine | Consumed (3.4.0) | Baseline (3.3.0) | Δ |
+|--------|-----------------|-----------------|---|
+| Jetty  | 41.03 KB | 41.94 KB | **−937 bytes** |
+| Tomcat | 45.56 KB | 44.78 KB | **+796 bytes** |
+| Netty  | 36.84 KB | 37.73 KB | **−917 bytes** |
+| CIO    | 42.27 KB | 41.29 KB | **+1,003 bytes** |
+
+</details>
+
+> [!TIP]
+> To see full per-file allocation diffs, ask Claude: *"show allocation diffs for 3.3.0..3.4.0"*,
+> or run the script manually:
+> ```bash
+> python3 .claude/skills/allocations/scripts/compute_diff.py v3.3.0..v3.4.0
+> ```

--- a/allocation-benchmark/3.4.1.md
+++ b/allocation-benchmark/3.4.1.md
@@ -1,0 +1,104 @@
+## Allocation Benchmark Results: 3.4.0 → 3.4.1
+
+> ⚠️ This report was generated with AI assistance and may contain incorrect attributions or false claims. Please verify before publishing.
+
+### Key Takeaways
+
+**Improvements**
+
+- **HTTP version strings no longer allocated per request** (server, all engines). [KTOR-9382 / #5382](https://github.com/ktorio/ktor/pull/5382) added a fast path that returns cached `HttpProtocolVersion` constants for the four common versions instead of calling `split()`. Result: 816–1632 bytes saved per request → **0**.
+
+- **`Date` header construction is now allocation-free** (nearly). [KTOR-9381 / #5380](https://github.com/ktorio/ktor/pull/5380) replaced `GregorianCalendar` with a direct arithmetic algorithm, eliminating the `Calendar` and `Gregorian$Date` objects created on every response. Client: −960 bytes/request (−89%). Server (file response): −480 bytes/request (−45%).
+
+- **`Accept-Charset: UTF-8` header no longer added by default.** [KTOR-5616 / #5378](https://github.com/ktorio/ktor/pull/5378) Removing this header eliminates an entire processing pass through `HttpPlainText`, `StringValues`, `CaseInsensitiveMap`, `URLBuilder`, and related collections — saving 200–400 bytes each per request on all client engines. Together with [KTOR-9344 / #5408](https://github.com/ktorio/ktor/pull/5408) (dispatcher switching disabled, which halves the size of coroutine context objects on the request path), this accounts for the consistent ~1,500-byte per-request drop across all infrastructure files.
+
+- **Hello World footprint down ~9–11% on all client engines** (Apache −9.7%, OkHttp −10.6%, Java −10.4%, CIO −8.3%) — cumulative effect of the three improvements above.
+
+- **CIO handles large chunked responses much more efficiently.** [KTOR-9263 / #5324](https://github.com/ktorio/ktor/pull/5324) rewrote the chunk-size parser as a state machine, reducing the number of channel read operations per chunk. For a large streaming or gzip-compressed response, this saves ~74 KB in `ByteReadChannelOperations` and ~48 KB in `ByteChannel` allocations — a **3.9% reduction** for the streaming test overall.
+
+**Regressions**
+
+- **Chunked parsing now allocates coroutine objects per chunk** (~33 KB for large responses). The same state-machine rewrite ([KTOR-9263 / #5324](https://github.com/ktorio/ktor/pull/5324)) introduces two `suspend` helpers (`parseChunkSize`, `skipCrLf`) that each create a coroutine continuation per chunk, plus a boxed `Long` per chunk size. This is the direct trade-off for the large savings above — net result is still strongly positive for any response with many chunks.
+
+- **Netty request handling allocates ~345 bytes more per request** (helloWorld). [KTOR-9334 / #5364](https://github.com/ktorio/ktor/pull/5364) fixed a correctness bug where route handlers ran on `Dispatchers.Unconfined` by restoring the Netty dispatcher into the coroutine context. The cost is a new `finishSuspend` coroutine, a `DisposeOnCancel` handler, and a `StackTraceElement[]` per request.
+
+- **OkHttp streaming allocates ~3.4 KB more** (0.3% of test total). [KTOR-9339 / #5370](https://github.com/ktorio/ktor/pull/5370) reverted a duplex-handling change in `StreamRequestBody`, switching non-duplex requests to a `toInputStream()` path. The effect on response-side allocation is small and may partly be measurement noise.
+
+---
+
+### Client
+
+<details>
+<summary><code>helloWorldFootprint</code> · <code>fileResponseFootprint</code> · <code>gzipResponseFootprint</code> · <code>streamingResponseFootprint</code></summary>
+
+#### `helloWorldFootprint` — simple request/response
+
+| Engine | Consumed (3.4.1) | Baseline (3.4.0) | Δ |
+|--------|-----------------|-----------------|---|
+| CIO    | 46.20 KB | 50.36 KB | **−4,255 bytes (−8.3%)** |
+| Apache | 31.12 KB | 34.45 KB | **−3,408 bytes (−9.7%)** |
+| OkHttp | 28.00 KB | 31.31 KB | **−3,395 bytes (−10.6%)** |
+| Java   | 30.46 KB | 34.00 KB | **−3,615 bytes (−10.4%)** |
+
+#### `fileResponseFootprint` — file download
+
+| Engine | Consumed (3.4.1) | Baseline (3.4.0) | Δ |
+|--------|-----------------|-----------------|---|
+| CIO    | 2,366.28 KB | 2,370.17 KB | **−3,982 bytes** |
+| Apache | 2,346.16 KB | 2,349.38 KB | **−3,298 bytes** |
+| OkHttp | 2,345.95 KB | 2,349.05 KB | **−3,168 bytes** |
+| Java   | 2,348.91 KB | 2,352.34 KB | **−3,513 bytes** |
+
+#### `gzipResponseFootprint` — gzip-compressed response
+
+| Engine | Consumed (3.4.1) | Baseline (3.4.0) | Δ |
+|--------|-----------------|-----------------|---|
+| CIO    | 6,378.44 KB | 6,430.22 KB | **−53,031 bytes** |
+| Apache | 6,209.95 KB | 6,213.56 KB | **−3,695 bytes** |
+| OkHttp | 6,226.53 KB | 6,230.27 KB | **−3,828 bytes** |
+| Java   | 6,289.91 KB | 6,294.09 KB | **−4,278 bytes** |
+
+#### `streamingResponseFootprint` — streaming response body
+
+| Engine | Consumed (3.4.1) | Baseline (3.4.0) | Δ |
+|--------|-----------------|-----------------|---|
+| CIO    | 2,278.27 KB | 2,369.95 KB | **−93,872 bytes (−3.9%)** |
+| Apache | 2,110.89 KB | 2,123.22 KB | **−12,619 bytes** |
+| OkHttp | 3,200.93 KB | 3,225.91 KB | **−25,578 bytes** |
+| Java   | 2,191.05 KB | 2,214.03 KB | **−23,537 bytes** |
+
+</details>
+
+---
+
+### Server
+
+<details>
+<summary><code>fileResponseFootprint</code> · <code>helloWorldFootprint</code></summary>
+
+#### `fileResponseFootprint` — file response
+
+| Engine | Consumed (3.4.1) | Baseline (3.4.0) | Δ |
+|--------|-----------------|-----------------|---|
+| Jetty  | 39.75 KB | 41.03 KB | **−1,311 bytes** |
+| Tomcat | 44.30 KB | 45.56 KB | **−1,292 bytes** |
+| Netty  | 35.64 KB | 36.84 KB | **−1,224 bytes** |
+| CIO    | 40.21 KB | 42.27 KB | **−2,112 bytes** |
+
+#### `helloWorldFootprint` — simple response
+
+| Engine | Consumed (3.4.1) | Baseline (3.4.0) | Δ |
+|--------|-----------------|-----------------|---|
+| Jetty  | 9.74 KB  | 10.53 KB | **−816 bytes** |
+| Tomcat | 16.34 KB | 17.15 KB | **−831 bytes** |
+| Netty  | 10.20 KB | 10.66 KB | **−471 bytes** |
+| CIO    | 18.20 KB | 19.79 KB | **−1,633 bytes** |
+
+</details>
+
+> [!TIP]
+> To see full per-file allocation diffs, ask Claude: *"show allocation diffs for 3.4.0..3.4.1"*,
+> or run the script manually:
+> ```bash
+> python3 .claude/skills/allocations/scripts/compute_diff.py v3.4.0..v3.4.1
+> ```

--- a/allocation-benchmark/README.md
+++ b/allocation-benchmark/README.md
@@ -72,6 +72,14 @@ Then open your browser to the displayed URL. The report server provides two view
 
 ## Baseline Management
 
+### Version tags
+
+Each released Ktor version has a corresponding git tag in this repository using the same `vX.Y.Z` format as the Ktor repo (e.g. `v3.4.1`).
+Tags point to the commit that committed the allocation baseline for that release.
+Use them to compare baselines between versions.
+
+### Baseline files
+
 Baselines are stored as JSON files in `allocations/`:
 - `helloWorld[EngineName].json` - Server hello world endpoint allocations
 - `fileResponse[EngineName].json` - Server file response allocations


### PR DESCRIPTION
Adds a Claude Code AI skill for managing Ktor allocation benchmark data, and the first two reports produced with it (3.4.0 and 3.4.1).

### Skill: `allocations`

Three commands, each backed by a reference doc that Claude follows step-by-step:

| Command | What it does |
|---------|-------------|
| `diff OLD NEW` | Prints full per-file allocation diffs between two version tags |
| `update [hints…]` | Gets fresh dumps (locally or from TeamCity CI), verifies them against provided PR/YouTrack hints, attributes unexplained changes via `check_sites.py` + git log, and commits an updated baseline + `pending.md` |
| `release OLD NEW` | Promotes `pending.md` to a versioned report file, updates the header, and bumps `ktor` in `libs.versions.toml` |

### Scripts

Three standalone Python scripts (also used by the skill internally):

- **`sources.py`** — `GitSource` / `LocalSource` abstraction; reads allocation dumps from git commits or local directories
- **`compute_diff.py`** — diffs `locationSize` per source file across all scenarios and engines; git mode (`vOLD..vNEW`) or local mode (`--local`, compares `allocations/` vs `build/allocations/`)
- **`check_sites.py`** — for a given scenario and source file, shows added / removed / changed allocation call sites between two snapshots; same two modes

### Reports

- `allocation-benchmark/3.4.0.md` — 3.3.0 → 3.4.0 comparison
- `allocation-benchmark/3.4.1.md` — 3.4.0 → 3.4.1 comparison

---
- **Next step:** [KTOR-8534](https://youtrack.jetbrains.com/issue/KTOR-8534) Benchmarks: Automatically update baseline