### PR TITLE
Add configurable allocation tolerances

### DIFF
--- a/.claude/skills/allocations/SKILL.md
+++ b/.claude/skills/allocations/SKILL.md
@@ -5,7 +5,7 @@ description: Use when working with Ktor memory allocation benchmarks — showing
 
 ## Overview
 
-Manages Ktor allocation benchmark data: diffing two versions, updating the committed baseline after PRs merge, and finalizing release reports.
+Manages Ktor allocation benchmark data: diffing two versions, updating the committed baseline after PRs merge, and finalizing release reports. Diff analysis honors documented bounds in `allocation-benchmark/allocations/tolerances.json` while always reporting raw changes.
 
 ## Commands
 

--- a/.claude/skills/allocations/references/investigate-diff.md
+++ b/.claude/skills/allocations/references/investigate-diff.md
@@ -4,6 +4,8 @@
 
 From `compute_diff.py` output, identify:
 
+**Known variances** — `allocation-benchmark/allocations/tolerances.json` documents bounded measurement artifacts. When a known variance is relevant to a comparison, the scripts print its configured bound, reason, and reference beside the matching location. Never hide the raw delta. Treat a change as known variance only when it remains within the bound and `check_sites.py` confirms the call sites still match the documented reason. Investigate excess or mismatched changes normally.
+
 **Consistent changes** — files that moved by a similar amount across *multiple* engines/scenarios point to a shared cause.
 
 **Large outliers** — a single-file change that is 10× larger than the rest deserves individual explanation.
@@ -34,7 +36,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/check_sites.py vOLD_VERSION[..vNEW_VERSION] 
   FileName.kt
 ```
 
-The class names and stack frames in the output are authoritative: they confirm exactly what is being allocated and from which call path.
+The class names and stack frames in the output are authoritative: they confirm exactly what is being allocated and from which call path. When the script prints known-variance metadata, verify these frames against its reason before accepting the exclusion.
 
 ## Deep investigation — attributing changes to PRs
 

--- a/.claude/skills/allocations/scripts/check_sites.py
+++ b/.claude/skills/allocations/scripts/check_sites.py
@@ -18,7 +18,7 @@ Run from the ktor-benchmarks repository root.
 
 import sys
 
-from sources import git_sources, local_sources
+from sources import git_sources, known_location_variance, local_sources
 
 
 # ---------------------------------------------------------------------------
@@ -32,15 +32,23 @@ if len(sys.argv) >= 2 and sys.argv[1] == "--local":
     scenario = sys.argv[2]
     source_file = sys.argv[3]
     old_source, new_source = local_sources()
+    tolerance_source = old_source
     mode = "--local"
 else:
     if len(sys.argv) < 4:
         print(__doc__)
         sys.exit(1)
     old_source, new_source = git_sources(sys.argv[1])
+    tolerance_source = new_source
     scenario = sys.argv[2]
     source_file = sys.argv[3]
     mode = f"{old_source.ref}..{new_source.ref}"
+
+variance = known_location_variance(
+    tolerance_source.load_tolerances(),
+    scenario,
+    source_file,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -148,6 +156,11 @@ if not added and not removed and not changed:
     sys.exit(0)
 
 print(f"\n{scenario} / {source_file}  {mode}")
+if variance:
+    print(f"  Known variance: up to {variance['knownVarianceBytes']:,} bytes")
+    print(f"  Reason: {variance['reason']}")
+    if variance.get("reference"):
+        print(f"  See: {variance['reference']}")
 
 entries = []
 

--- a/.claude/skills/allocations/scripts/compute_diff.py
+++ b/.claude/skills/allocations/scripts/compute_diff.py
@@ -17,11 +17,12 @@ Options:
 Run from the ktor-benchmarks repository root.
 """
 
+import math
 import re
 import subprocess
 import sys
 
-from sources import git_sources, local_sources
+from sources import git_sources, known_location_variance, local_sources
 
 SUBDIRS = {"server": "", "client": "client"}
 
@@ -47,15 +48,19 @@ if "--threshold" in args:
 
 if args and args[0] == "--local":
     old_source, new_source = local_sources()
+    tolerance_source = old_source
     mode = "--local"
 else:
     if not args:
         print(__doc__)
         sys.exit(1)
     old_source, new_source = git_sources(args[0])
+    tolerance_source = new_source
     mode = f"{old_source.ref}..{new_source.ref}"
 
-print(f"{mode}  --threshold={threshold}")
+tolerances = tolerance_source.load_tolerances()
+allowed_ratio = tolerances.get("defaultAllowedIncreaseRatio", 0.0)
+print(f"{mode}  --threshold={threshold}  --allowed-increase={allowed_ratio:.2%}")
 
 
 # ---------------------------------------------------------------------------
@@ -96,7 +101,9 @@ for side, subdir in SUBDIRS.items():
             if d != 0:
                 diffs.append((d, k, old.get(k, 0), new.get(k, 0)))
         diffs.sort(key=lambda x: (int(x[0] < 0), -abs(x[0])))
+        report_name = f"{subdir}/{scenario}[{engine}]" if subdir else f"{scenario}[{engine}]"
         results.setdefault(key, {})[engine] = {
+            "report_name": report_name,
             "old_total": old_total,
             "new_total": new_total,
             "delta": new_total - old_total,
@@ -112,15 +119,52 @@ for scenario, engines in results.items():
         print(f"  {engine}: {old_kb:.2f} KB → {new_kb:.2f} KB  ({delta:+,})")
         hidden_count = 0
         hidden_sum = 0
+        consumed_known_variance = 0
+        allowed_difference = math.floor(data["old_total"] * allowed_ratio + 0.5)
+        apply_known_variance = delta > allowed_difference
         for d, fname, o, n in data["diffs"]:
+            variance = known_location_variance(tolerances, data["report_name"], fname)
+            show_known_variance = variance and (d < 0 or apply_known_variance)
+            if show_known_variance:
+                variance_bytes = variance["knownVarianceBytes"]
+                if d > 0:
+                    consumed_known_variance += min(d, variance_bytes)
+                observed_variance = abs(d)
+                annotation = f"  [known variance up to {variance_bytes:,} bytes"
+                if observed_variance > variance_bytes:
+                    annotation += f"; exceeds bound by {observed_variance - variance_bytes:,}"
+                annotation += "]"
+            else:
+                annotation = ""
+
             if o == 0:
-                print(f"    +{n:,}  {fname}")
+                print(f"    +{n:,}  {fname}{annotation}")
             elif n == 0:
-                print(f"    -{o:,}  {fname}")
-            elif abs(d) < threshold:
+                print(f"    -{o:,}  {fname}{annotation}")
+            elif abs(d) < threshold and not show_known_variance:
                 hidden_count += 1
                 hidden_sum += d
             else:
-                print(f"    {d:+,} ({o:,} → {n:,})  {fname}")
+                print(f"    {d:+,} ({o:,} → {n:,})  {fname}{annotation}")
+
+            if show_known_variance:
+                print(f"      {variance['reason']}")
+                if variance.get("reference"):
+                    print(f"      See: {variance['reference']}")
+
         if hidden_count:
             print(f"    ({hidden_count} below threshold, net {hidden_sum:+,})")
+        effective_delta = delta - consumed_known_variance
+        unexpected_increase = max(effective_delta - allowed_difference, 0)
+        if consumed_known_variance:
+            print(
+                f"    Known variance consumed: {consumed_known_variance:,} bytes; "
+                f"effective delta: {effective_delta:+,}; "
+                f"default tolerance: {allowed_difference:,}; "
+                f"unexpected increase: {unexpected_increase:,}"
+            )
+        elif unexpected_increase:
+            print(
+                f"    Default tolerance: {allowed_difference:,} bytes; "
+                f"unexpected increase: {unexpected_increase:,}"
+            )

--- a/.claude/skills/allocations/scripts/sources.py
+++ b/.claude/skills/allocations/scripts/sources.py
@@ -1,12 +1,75 @@
 """Shared allocation data sources for compute_diff.py and check_sites.py."""
 
 import json
+import math
 import os
 import subprocess
 
 REPO = os.getcwd()
 ALLOC_GIT_ROOT = "allocation-benchmark/allocations"
 ALLOC_LOCAL_ROOT = "allocation-benchmark/build/allocations"
+TOLERANCES_FILE = "tolerances.json"
+
+
+def validate_tolerances(metadata):
+    if not isinstance(metadata, dict):
+        raise ValueError("Tolerance metadata must be a JSON object")
+
+    allowed_root_keys = {"defaultAllowedIncreaseRatio", "reports"}
+    unknown_root_keys = set(metadata) - allowed_root_keys
+    if unknown_root_keys:
+        raise ValueError(f"Unknown tolerance metadata keys: {sorted(unknown_root_keys)}")
+
+    ratio = metadata.get("defaultAllowedIncreaseRatio")
+    if (
+        isinstance(ratio, bool)
+        or not isinstance(ratio, (int, float))
+        or not math.isfinite(ratio)
+        or ratio < 0
+    ):
+        raise ValueError("defaultAllowedIncreaseRatio must be a non-negative number")
+
+    reports = metadata.get("reports", {})
+    if not isinstance(reports, dict):
+        raise ValueError("reports must be a JSON object")
+    for report_name, report in reports.items():
+        if not isinstance(report, dict) or set(report) - {"locations"}:
+            raise ValueError(f"Invalid tolerance metadata for report {report_name!r}")
+        locations = report.get("locations", {})
+        if not isinstance(locations, dict):
+            raise ValueError(f"locations must be a JSON object for report {report_name!r}")
+        for source_file, variance in locations.items():
+            if not isinstance(variance, dict):
+                raise ValueError(f"Invalid known variance for {report_name!r} / {source_file!r}")
+            unknown_variance_keys = set(variance) - {"knownVarianceBytes", "reason", "reference"}
+            if unknown_variance_keys:
+                raise ValueError(
+                    f"Unknown known-variance keys for {report_name!r} / {source_file!r}: "
+                    f"{sorted(unknown_variance_keys)}"
+                )
+            variance_bytes = variance.get("knownVarianceBytes")
+            if isinstance(variance_bytes, bool) or not isinstance(variance_bytes, int) or variance_bytes < 0:
+                raise ValueError(
+                    f"knownVarianceBytes must be a non-negative integer for "
+                    f"{report_name!r} / {source_file!r}"
+                )
+            reason = variance.get("reason")
+            if not isinstance(reason, str) or not reason.strip():
+                raise ValueError(f"reason must not be blank for {report_name!r} / {source_file!r}")
+            reference = variance.get("reference")
+            if reference is not None and not isinstance(reference, str):
+                raise ValueError(f"reference must be a string for {report_name!r} / {source_file!r}")
+
+    return metadata
+
+
+def known_location_variance(metadata, report_name, source_file):
+    return (
+        metadata.get("reports", {})
+        .get(report_name, {})
+        .get("locations", {})
+        .get(source_file)
+    )
 
 
 class GitSource:
@@ -29,6 +92,14 @@ class GitSource:
             return []
         return [f for f in out.splitlines() if f.endswith(".json") and "_sites" not in f]
 
+    def _exists(self, path):
+        output = subprocess.check_output(
+            ["git", "ls-tree", "--name-only", self.ref, "--", path],
+            cwd=REPO,
+            stderr=subprocess.DEVNULL,
+        )
+        return bool(output.strip())
+
     def _show(self, path):
         """Return file content at this ref, resolving LFS pointers if needed."""
         raw = subprocess.check_output(
@@ -39,6 +110,12 @@ class GitSource:
     def load(self, subdir, fname):
         git_dir = f"{ALLOC_GIT_ROOT}/{subdir}".rstrip("/")
         return json.loads(self._show(f"{git_dir}/{fname}"))
+
+    def load_tolerances(self):
+        path = f"{ALLOC_GIT_ROOT}/{TOLERANCES_FILE}"
+        if not self._exists(path):
+            return {}
+        return validate_tolerances(json.loads(self._show(path)))
 
     def load_sites(self, scenario, required=True):
         path = f"{ALLOC_GIT_ROOT}/{scenario}_sites.json"
@@ -71,6 +148,13 @@ class LocalSource:
         local_dir = os.path.join(self.root, subdir) if subdir else self.root
         with open(os.path.join(local_dir, fname)) as f:
             return json.load(f)
+
+    def load_tolerances(self):
+        path = os.path.join(self.root, TOLERANCES_FILE)
+        if not os.path.exists(path):
+            return {}
+        with open(path) as f:
+            return validate_tolerances(json.load(f))
 
     def load_sites(self, scenario, required=True):
         path = os.path.join(self.root, f"{scenario}_sites.json")

--- a/.claude/skills/allocations/scripts/test_sources.py
+++ b/.claude/skills/allocations/scripts/test_sources.py
@@ -1,0 +1,71 @@
+import unittest
+
+from sources import validate_tolerances
+
+
+class ValidateTolerancesTest(unittest.TestCase):
+    def test_accepts_valid_metadata(self):
+        metadata = {
+            "defaultAllowedIncreaseRatio": 0.005,
+            "reports": {
+                "client/streamingResponse[OkHttp]": {
+                    "locations": {
+                        "OkHttpEngine.kt": {
+                            "knownVarianceBytes": 278528,
+                            "reason": "Known scheduler variance",
+                            "reference": "allocation-benchmark/3.5.0.md",
+                        }
+                    }
+                }
+            },
+        }
+
+        self.assertIs(metadata, validate_tolerances(metadata))
+
+    def test_rejects_missing_default_ratio(self):
+        with self.assertRaisesRegex(ValueError, "defaultAllowedIncreaseRatio"):
+            validate_tolerances({"reports": {}})
+
+    def test_rejects_negative_default_ratio(self):
+        with self.assertRaisesRegex(ValueError, "defaultAllowedIncreaseRatio"):
+            validate_tolerances({"defaultAllowedIncreaseRatio": -0.1})
+
+    def test_rejects_negative_variance(self):
+        with self.assertRaisesRegex(ValueError, "knownVarianceBytes"):
+            validate_tolerances(
+                {
+                    "defaultAllowedIncreaseRatio": 0.005,
+                    "reports": {
+                        "scenario[Engine]": {
+                            "locations": {
+                                "Source.kt": {
+                                    "knownVarianceBytes": -1,
+                                    "reason": "Known variance",
+                                }
+                            }
+                        }
+                    },
+                }
+            )
+
+    def test_rejects_blank_reason(self):
+        with self.assertRaisesRegex(ValueError, "reason"):
+            validate_tolerances(
+                {
+                    "defaultAllowedIncreaseRatio": 0.005,
+                    "reports": {
+                        "scenario[Engine]": {
+                            "locations": {
+                                "Source.kt": {
+                                    "knownVarianceBytes": 1,
+                                    "reason": " ",
+                                }
+                            }
+                        }
+                    },
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/allocation-benchmark/README.md
+++ b/allocation-benchmark/README.md
@@ -68,7 +68,7 @@ Then open your browser to the displayed URL. The report server provides two view
 1. The Java agent (`instrumenter`) intercepts all object allocations during test execution
 2. Tests perform multiple warmup requests, then measure allocations over 300 requests
 3. Results are compared against baseline JSON files in the `allocations/` directory
-4. Tests fail if allocations deviate more than 12% from baseline
+4. Tests fail when an allocation increase exceeds the configured tolerance
 
 ## Baseline Management
 
@@ -86,6 +86,8 @@ Baselines are stored as JSON files in `allocations/`:
 - `plainText[EngineName].json` - Client plain text request allocations
 - `json[EngineName].json` - Client JSON request allocations
 
+`allocations/tolerances.json` defines the default allowed increase and bounded, report-specific known variances. Known variances must include a reason so tests and analysis tools can distinguish documented measurement artifacts from regressions. Raw allocation dumps and diffs are never adjusted.
+
 **When to update baselines:**
 - After intentional changes that affect memory usage
 - When CI consistently fails with allocation differences
@@ -101,7 +103,7 @@ Baselines are stored as JSON files in `allocations/`:
 Key parameters in tests:
 - `TEST_SIZE = 300L` - Number of requests measured per test
 - `WARMUP_SIZE = 20` - Number of warmup requests before measurement
-- `ALLOWED_MEMORY_DIFFERENCE_RATIO = 0.12` - 12% tolerance for allocation differences
+- `allocations/tolerances.json` - Default increase tolerance and report/location-specific known variance metadata
 
 ## TeamCity Integration
 

--- a/allocation-benchmark/allocations/tolerances.json
+++ b/allocation-benchmark/allocations/tolerances.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53e4098c60c6a54bb470ffdc4b01b7036c1d35d59033b4eb95924dcf5e51fae4
+size 418

--- a/allocation-benchmark/src/test/kotlin/ServerCallAllocationTest.kt
+++ b/allocation-benchmark/src/test/kotlin/ServerCallAllocationTest.kt
@@ -8,18 +8,12 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import utils.benchmarks.loadReport
-import utils.benchmarks.saveReport
-import utils.benchmarks.saveSiteStatistics
+import utils.benchmarks.*
 import kotlin.math.absoluteValue
-import kotlin.math.roundToLong
 
 const val TEST_SIZE = 300L
 const val WARMUP_SIZE = 20
 const val KB = 1024L
-
-// TODO investigate why TC has higher memory usage.
-const val ALLOWED_MEMORY_DIFFERENCE_RATIO = 0.12
 
 class ServerCallAllocationTest : BaseAllocationTest() {
 
@@ -89,37 +83,61 @@ abstract class BaseAllocationTest {
         val previousSnapshot = loadReport(reportName)
         val consumedMemory = snapshot.totalSize()
         val expectedMemory = previousSnapshot.totalSize()
+        val comparison = compareAllocations(
+            previous = previousSnapshot,
+            current = snapshot,
+            tolerance = loadAllocationTolerance(reportName),
+        )
 
-        val difference = consumedMemory - expectedMemory
-
-        val allowedDifference = (ALLOWED_MEMORY_DIFFERENCE_RATIO * expectedMemory).roundToLong()
-        val increase = maxOf(difference - allowedDifference, 0)
-        val success = increase == 0L
-        val message = """
-            Request consumes ${consumedMemory.kb}, expected ${expectedMemory.kb}. 
-              Difference: $difference ${if (success) "<" else ">"} $allowedDifference (allowed)
-              Consumed ${consumedMemory.kb} on request
-              Expected ${expectedMemory.kb} on request
-              ${if (difference > 0L) "Extra   " else "Saved   "} ${difference.absoluteValue.padEnd(3)} bytes on request
-            (See stdout + build/allocations/* files for details)
-        """.trimIndent().also(::println)
+        val difference = comparison.totalDifference
+        val success = comparison.unexpectedIncrease == 0L
+        val message = buildString {
+            appendLine("Request consumes ${consumedMemory.kb}, expected ${expectedMemory.kb}.")
+            if (comparison.consumedKnownVariance == 0L) {
+                appendLine(
+                    "  Difference: ${difference.withSign} " +
+                            "${if (success) "<=" else ">"} ${comparison.allowedDifference} (allowed)"
+                )
+            } else {
+                appendLine("  Raw difference: ${difference.withSign}")
+                appendLine(
+                    "  Difference after known variance: ${comparison.adjustedDifference.withSign} " +
+                            "${if (success) "<=" else ">"} ${comparison.allowedDifference} (allowed)"
+                )
+            }
+            appendLine(
+                "  ${if (difference > 0L) "Extra" else "Saved"} " +
+                        "${difference.absoluteValue} bytes on request"
+            )
+            append("(See stdout + build/allocations/* files for details)")
+        }.also(::println)
 
         if (SAVE_REPORT) {
             println("Report updated: $reportName")
             return
         }
 
-        val diffs = previousSnapshot diff snapshot
+        val diffs = comparison.locationDifferences
+        val consumedVariances = comparison.consumedLocationVariances.associateBy { it.locationName }
 
         println("\nIncreased locations:")
         diffs.filter { it.difference > 0 }
             .sortedByDescending { it.difference }.forEach { diff ->
+                val variance = consumedVariances[diff.locationName]
+                val varianceDescription = variance
+                    ?.let { "  [known variance up to ${it.configuredVariance.knownVarianceBytes} bytes]" }
+                    .orEmpty()
                 println(
                     "\t" +
                             diff.locationName.padEnd(40) +
-                            diff.difference.toString().padStart(10) +
-                            "    (${diff.previousSize.padEnd(12)} --> ${diff.currentSize.padStart(12)})"
+                            diff.difference.withSign.padStart(10) +
+                            "    (${diff.previousSize.padEnd(12)} --> ${diff.currentSize.padStart(12)})" +
+                            varianceDescription
                 )
+                if (variance != null) {
+                    println("\t    ${variance.configuredVariance.reason}")
+                    variance.configuredVariance.reference?.let { println("\t    See: $it") }
+                }
             }
 
         println("\nDecreased locations:")
@@ -133,7 +151,7 @@ abstract class BaseAllocationTest {
                 )
             }
 
-        assertEquals(0L, increase, message)
+        assertEquals(0L, comparison.unexpectedIncrease, message)
     }
 
     protected abstract suspend fun measureEngineRequest(
@@ -142,30 +160,8 @@ abstract class BaseAllocationTest {
         block: suspend () -> Unit,
     ): AllocationData
 
-    private infix fun AllocationData.diff(other: AllocationData): List<LocationDifference> {
-        val locations = this.packages.map { it.name }.toSet() + other.packages.map { it.name }.toSet()
-        return locations.map { location ->
-            LocationDifference(
-                previous = this[location],
-                current = other[location],
-            )
-        }
-    }
-
-    /**
-     * Represents a difference between two location infos.
-     */
-    private class LocationDifference(
-        val previous: LocationInfo?,
-        val current: LocationInfo?,
-    ) {
-        val previousSize = previous?.locationSize ?: 0L
-        val currentSize = current?.locationSize ?: 0L
-        val locationName = current?.name ?: previous?.name ?: "unknown"
-        val difference = currentSize - previousSize
-    }
-
     private val Long.kb get() = "%.2f KB".format(toDouble() / KB.toDouble())
+    private val Long.withSign get() = if (this > 0L) "+$this" else toString()
     private fun Long.padStart(padding: Int) = toString().padStart(padding)
     private fun Long.padEnd(padding: Int) = toString().padEnd(padding)
 }

--- a/allocation-benchmark/src/test/kotlin/utils/AllocationTolerance.kt
+++ b/allocation-benchmark/src/test/kotlin/utils/AllocationTolerance.kt
@@ -1,0 +1,136 @@
+package utils.benchmarks
+
+import benchmarks.AllocationData
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlin.io.path.Path
+import kotlin.io.path.exists
+import kotlin.io.path.inputStream
+import kotlin.math.roundToLong
+
+private const val TOLERANCES_FILE = "allocations/tolerances.json"
+
+@OptIn(ExperimentalSerializationApi::class)
+private val toleranceMetadata by lazy {
+    val toleranceFile = Path(TOLERANCES_FILE)
+    check(toleranceFile.exists()) { "Allocation tolerance metadata not found: $TOLERANCES_FILE" }
+    Json.decodeFromStream<AllocationToleranceMetadata>(toleranceFile.inputStream())
+}
+
+fun loadAllocationTolerance(reportName: String): AllocationTolerance =
+    toleranceMetadata.toleranceFor(reportName)
+
+fun compareAllocations(
+    previous: AllocationData,
+    current: AllocationData,
+    tolerance: AllocationTolerance,
+): AllocationComparisonResult {
+    val locationNames = previous.packages.map { it.name }.toSet() + current.packages.map { it.name }.toSet()
+    val locationDifferences = locationNames.map { locationName ->
+        LocationDifference(
+            locationName = locationName,
+            previousSize = previous[locationName]?.locationSize ?: 0L,
+            currentSize = current[locationName]?.locationSize ?: 0L,
+        )
+    }
+    val totalDifference = current.totalSize() - previous.totalSize()
+    val allowedDifference = (tolerance.allowedIncreaseRatio * previous.totalSize()).roundToLong()
+    val consumedLocationVariances = if (totalDifference > allowedDifference) {
+        locationDifferences.mapNotNull { difference -> tolerance.tryConsumeVariance(difference) }
+    } else {
+        emptyList()
+    }
+
+    val consumedKnownVariance = consumedLocationVariances.sumOf { it.consumedBytes }
+    val adjustedDifference = totalDifference - consumedKnownVariance
+    val unexpectedIncrease = (adjustedDifference - allowedDifference).coerceAtLeast(0L)
+
+    return AllocationComparisonResult(
+        totalDifference = totalDifference,
+        consumedKnownVariance = consumedKnownVariance,
+        adjustedDifference = adjustedDifference,
+        allowedDifference = allowedDifference,
+        unexpectedIncrease = unexpectedIncrease,
+        locationDifferences = locationDifferences,
+        consumedLocationVariances = consumedLocationVariances,
+    )
+}
+
+
+@Serializable
+data class AllocationToleranceMetadata(
+    val defaultAllowedIncreaseRatio: Double,
+    val reports: Map<String, ReportTolerance> = emptyMap(),
+) {
+    init {
+        require(defaultAllowedIncreaseRatio >= 0.0) {
+            "defaultAllowedIncreaseRatio must not be negative"
+        }
+    }
+
+    fun toleranceFor(reportName: String): AllocationTolerance = AllocationTolerance(
+        allowedIncreaseRatio = defaultAllowedIncreaseRatio,
+        locations = reports[reportName]?.locations.orEmpty(),
+    )
+}
+
+@Serializable
+data class ReportTolerance(
+    val locations: Map<String, KnownLocationVariance> = emptyMap(),
+)
+
+@Serializable
+data class KnownLocationVariance(
+    val knownVarianceBytes: Long,
+    val reason: String,
+    val reference: String? = null,
+) {
+    init {
+        require(knownVarianceBytes >= 0L) { "knownVarianceBytes must not be negative" }
+        require(reason.isNotBlank()) { "reason must not be blank" }
+    }
+
+    fun tryConsumeVariance(difference: LocationDifference): ConsumedLocationVariance? {
+        val consumedBytes = minOf(
+            difference.difference.coerceAtLeast(0L),
+            knownVarianceBytes,
+        )
+        if (consumedBytes == 0L) return null
+        return ConsumedLocationVariance(difference.locationName, consumedBytes, this)
+    }
+}
+
+data class AllocationTolerance(
+    val allowedIncreaseRatio: Double,
+    val locations: Map<String, KnownLocationVariance>,
+) {
+
+    fun tryConsumeVariance(difference: LocationDifference): ConsumedLocationVariance? =
+        locations[difference.locationName]?.tryConsumeVariance(difference)
+}
+
+data class LocationDifference(
+    val locationName: String,
+    val previousSize: Long,
+    val currentSize: Long,
+) {
+    val difference: Long = currentSize - previousSize
+}
+
+data class ConsumedLocationVariance(
+    val locationName: String,
+    val consumedBytes: Long,
+    val configuredVariance: KnownLocationVariance,
+)
+
+data class AllocationComparisonResult(
+    val totalDifference: Long,
+    val consumedKnownVariance: Long,
+    val adjustedDifference: Long,
+    val allowedDifference: Long,
+    val unexpectedIncrease: Long,
+    val locationDifferences: List<LocationDifference>,
+    val consumedLocationVariances: List<ConsumedLocationVariance>,
+)

--- a/allocation-benchmark/src/test/kotlin/utils/AllocationToleranceTest.kt
+++ b/allocation-benchmark/src/test/kotlin/utils/AllocationToleranceTest.kt
@@ -1,0 +1,133 @@
+package utils.benchmarks
+
+import benchmarks.AllocationData
+import benchmarks.LocationInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AllocationToleranceTest {
+    @Test
+    fun `resolves report tolerance from metadata`() {
+        val metadata = AllocationToleranceMetadata(
+            defaultAllowedIncreaseRatio = 0.01,
+            reports = mapOf(
+                "scenario[Engine]" to ReportTolerance(
+                    locations = mapOf(
+                        "Source.kt" to KnownLocationVariance(
+                            knownVarianceBytes = 1_024L,
+                            reason = "Test variance",
+                        )
+                    )
+                )
+            ),
+        )
+
+        val tolerance = metadata.toleranceFor("scenario[Engine]")
+
+        assertEquals(0.01, tolerance.allowedIncreaseRatio)
+        assertEquals(1_024L, tolerance.locations.getValue("Source.kt").knownVarianceBytes)
+    }
+
+    @Test
+    fun `consumes only configured location increase`() {
+        val comparison = compareAllocations(
+            previous = allocations("Known.kt" to 100L, "Other.kt" to 100L),
+            current = allocations("Known.kt" to 350L, "Other.kt" to 100L),
+            tolerance = tolerance(
+                allowedIncreaseRatio = 0.0,
+                "Known.kt" to 200L,
+            ),
+        )
+
+        assertEquals(250L, comparison.totalDifference)
+        assertEquals(200L, comparison.consumedKnownVariance)
+        assertEquals(50L, comparison.adjustedDifference)
+        assertEquals(50L, comparison.unexpectedIncrease)
+    }
+
+    @Test
+    fun `unused location variance does not hide other increase`() {
+        val comparison = compareAllocations(
+            previous = allocations("Known.kt" to 100L, "Other.kt" to 100L),
+            current = allocations("Known.kt" to 100L, "Other.kt" to 150L),
+            tolerance = tolerance(
+                allowedIncreaseRatio = 0.0,
+                "Known.kt" to 200L,
+            ),
+        )
+
+        assertEquals(0L, comparison.consumedKnownVariance)
+        assertEquals(50L, comparison.adjustedDifference)
+        assertEquals(50L, comparison.unexpectedIncrease)
+    }
+
+    @Test
+    fun `does not consume known variance when default tolerance is sufficient`() {
+        val comparison = compareAllocations(
+            previous = allocations("Known.kt" to 900L, "Other.kt" to 100L),
+            current = allocations("Known.kt" to 910L, "Other.kt" to 100L),
+            tolerance = tolerance(
+                allowedIncreaseRatio = 0.01,
+                "Known.kt" to 200L,
+            ),
+        )
+
+        assertEquals(10L, comparison.totalDifference)
+        assertEquals(0L, comparison.consumedKnownVariance)
+        assertEquals(10L, comparison.adjustedDifference)
+        assertEquals(0L, comparison.unexpectedIncrease)
+    }
+
+    @Test
+    fun `does not consume known variance for decrease`() {
+        val comparison = compareAllocations(
+            previous = allocations("Known.kt" to 300L, "Other.kt" to 100L),
+            current = allocations("Known.kt" to 100L, "Other.kt" to 150L),
+            tolerance = tolerance(
+                allowedIncreaseRatio = 0.0,
+                "Known.kt" to 200L,
+            ),
+        )
+
+        assertEquals(0L, comparison.consumedKnownVariance)
+        assertEquals(-150L, comparison.adjustedDifference)
+        assertEquals(0L, comparison.unexpectedIncrease)
+    }
+
+    @Test
+    fun `applies known variance when default tolerance is exceeded`() {
+        val comparison = compareAllocations(
+            previous = allocations("Known.kt" to 900L, "Other.kt" to 100L),
+            current = allocations("Known.kt" to 1_100L, "Other.kt" to 110L),
+            tolerance = tolerance(
+                allowedIncreaseRatio = 0.01,
+                "Known.kt" to 200L,
+            ),
+        )
+
+        assertEquals(210L, comparison.totalDifference)
+        assertEquals(200L, comparison.consumedKnownVariance)
+        assertEquals(10L, comparison.adjustedDifference)
+        assertEquals(10L, comparison.allowedDifference)
+        assertEquals(0L, comparison.unexpectedIncrease)
+    }
+
+    private fun allocations(vararg locations: Pair<String, Long>) = AllocationData(
+        data = locations.associateTo(mutableMapOf()) { (name, size) ->
+            name to LocationInfo(name = name, locationSize = size)
+        }
+    )
+
+    private fun tolerance(
+        allowedIncreaseRatio: Double,
+        vararg locations: Pair<String, Long>,
+    ) = AllocationTolerance(
+        allowedIncreaseRatio = allowedIncreaseRatio,
+        locations = locations.associate { (name, bytes) ->
+            name to KnownLocationVariance(
+                knownVarianceBytes = bytes,
+                reason = "Test variance",
+            )
+        },
+    )
+}


### PR DESCRIPTION
## Summary

- replace the broad 12% allocation threshold with versioned tolerance metadata
- support bounded per-report, per-location known variances while preserving raw allocation diffs
- teach the allocation analysis skill and scripts to load, validate, and report tolerance metadata

## Validation

- `AllocationToleranceTest`: 6 tests passed
- Python tolerance metadata tests: 5 tests passed
- streaming response allocation scenarios: 4 tests passed